### PR TITLE
Corrected URL for branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 NOTICE: At present, the master branch will only be a text file until I can figure out how to include all of the versions in one package.
 
-As of the time of this writing, the current version is 5.3.1, and setup is relatively straightforward: ``cordova plugin add https://github.com/agamemnus/cordova-plugin-xapkreader#5.3.1``.
+As of the time of this writing, the current version is 5.3.1, and setup is relatively straightforward: ``cordova plugin add https://github.com/agamemnus/cordova-plugin-xapkreader#cordova-5.3.1``.
 
-There is also a Cordova 5.0 version (because of the somewhat difficult bugs with it, it's not trivial to set it up correctly): ``cordova plugin add https://github.com/agamemnus/cordova-plugin-xapkreader#5.0``.
+There is also a Cordova 5.0 version (because of the somewhat difficult bugs with it, it's not trivial to set it up correctly): ``cordova plugin add https://github.com/agamemnus/cordova-plugin-xapkreader#cordova-5.0``.
 
 If you need a Cordova pre-gradle version (which is I think Cordova 3.6?), use the pre-gradle branch: ``cordova plugin add https://github.com/agamemnus/cordova-plugin-xapkreader#pre-gradle``.


### PR DESCRIPTION
You were missing "cordova-" from the branch identifier.