### PR TITLE
Customizable xapkreader.xml data now read upon installing the plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -17,20 +17,32 @@
     <param name="onload" value="true" />
    </feature>
   </config-file>
-  
+
+  <preference name="XAPK_EXPANSION_AUTHORITY" default="$PACKAGE_NAME" />
+  <preference name="XAPK_PUBLIC_KEY" />
+  <preference name="XAPK_TEXT_DL_ASSETS" default="Downloading assets…" />
+  <preference name="XAPK_TEXT_PR_ASSETS" default="Preparing assets…" />
+  <preference name="XAPK_TEXT_DL_FAILED" default="Download failed." />
+  <preference name="XAPK_TEXT_ERROR" default="Error." />
+  <preference name="XAPK_TEXT_CLOSE" default="Close." />
+  <preference name="XAPK_MAIN_VERSION" default="0" />
+  <preference name="XAPK_PATCH_VERSION" default="0" />
+  <preference name="XAPK_MAIN_FILESIZE" default="0" />
+  <preference name="XAPK_PATCH_FILESIZE" default="0" />
+
   <source-file src="res/values/xapkreader.xml" target-dir="res/values" />
   <config-file target="res/values/xapkreader.xml" parent="/*">
-   <string name="xapk_expansion_authority">com.test.expansion</string>
-   <string name="xapk_google_play_public_key">YOUR_GOOGLE_PLAY_LICENSE_KEY</string>
-   <string name="xapk_text_downloading_assets">Downloading assets…</string>
-   <string name="xapk_text_preparing_assets">Preparing assets…</string>
-   <string name="xapk_text_download_failed">Download failed.</string>
-   <string name="xapk_text_error">Error.</string>
-   <string name="xapk_text_close">Close.</string>
-   <integer name="xapk_main_version">0</integer>
-   <integer name="xapk_patch_version">0</integer>
-   <integer name="xapk_main_file_size">0</integer>
-   <integer name="xapk_patch_file_size">0</integer>
+   <string name="xapk_expansion_authority">$XAPK_EXPANSION_AUTHORITY</string>
+   <string name="xapk_google_play_public_key">$XAPK_PUBLIC_KEY</string>
+   <string name="xapk_text_downloading_assets">$XAPK_TEXT_DL_ASSETS</string>
+   <string name="xapk_text_preparing_assets">$XAPK_TEXT_PR_ASSETS</string>
+   <string name="xapk_text_download_failed">$XAPK_TEXT_DL_FAILED</string>
+   <string name="xapk_text_error">$XAPK_TEXT_ERROR</string>
+   <string name="xapk_text_close">$XAPK_TEXT_CLOSE</string>
+   <integer name="xapk_main_version">$XAPK_MAIN_VERSION</integer>
+   <integer name="xapk_patch_version">$XAPK_PATCH_VERSION</integer>
+   <integer name="xapk_main_file_size">$XAPK_MAIN_FILESIZE</integer>
+   <integer name="xapk_patch_file_size">$XAPK_PATCH_FILESIZE</integer>
   </config-file>
   
   <source-file src="src/android/XAPKAlarmReceiver.java"      target-dir="src/com/flyingsoftgames/xapkreader" />


### PR DESCRIPTION
With this change users are no longer forced to commit files from the plugin in order to keep their configuration. They simply have to keep their root config.xml up to date by setting some `variable` tags in the `plugin` tag that defines this plugin. The only required value that does not have a default is `XAPK_PUBLIC_KEY`, because it would be different for every developer/team.
In the examples I use my own url, since this is not (yet) in the main project.

```xml
    <plugin name="com.flyingsoftgames.xapkreader" spec="https://github.com/coladict/cordova-plugin-xapkreader#cordova-5.3.1">
		<variable name="XAPK_PUBLIC_KEY" value="INSERT YOUR VERY LONG KEY HERE" />
    </plugin>
```
Then when the project is newly cloned, all they have to run is `cordova prepare` to install the platforms and plugins.

A new user adding the plugin would previously have to use the command line

    cordova plugin add https://github.com/agamemnus/cordova-plugin-xapkreader#cordova-5.3.1 --save

Now they also have to add the parameters

    --variable XAPK_PUBLIC_KEY=YOUR_VERY_LONG_KEY_HERE

Thus the full command line becomes

    cordova plugin add https://github.com/coladict/cordova-plugin-xapkreader#cordova-5.3.1 --save --variable XAPK_PUBLIC_KEY=YOUR_VERY_LONG_KEY_HERE

I tested this, and the `xapk_expansion_authority` value in `platforms/android/res/values/xapkreader.xml` is also correct, even though in the generated `plugins/android.json`, the value of `installed_plugins["com.flyingsoftgames.xapkreader"]["XAPK_EXPANSION_AUTHORITY"]` is `$PACKAGE_NAME`. The value is being replaced where it matters.

**This change requires new instructions for users.**

The `XAPK_PUBLIC_KEY` variable intentionally does not have a default value, in order to force the users to take a better look at the instructions, which will need to be written for this.

I realize this may not be the right branch to request the PR to, but this also isn't how branches should be managed. `cordova-5.3.1` should have been a tag in a `cordova-5` branch.