### PR TITLE
Compatibility improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+
+.gitignore
+.idea/
+android-sdk/extras/google/play_apk_expansion/downloader_library/downloader_library.iml
+android-sdk/extras/google/play_apk_expansion/downloader_library/gen/com/android/vending/expansion/downloader/Manifest.java
+android-sdk/extras/google/play_licensing/library/gen/com/google/android/vending/licensing/Manifest.java
+android-sdk/extras/google/play_licensing/library/gen/com/google/android/vending/licensing/R.java
+android-sdk/extras/google/play_licensing/library/library.iml
+src/cordova-plugin-xapkreader.iml

--- a/android-sdk/extras/google/play_apk_expansion/downloader_library/build-extras.gradle
+++ b/android-sdk/extras/google/play_apk_expansion/downloader_library/build-extras.gradle
@@ -2,3 +2,7 @@ dependencies {
     debugCompile project(path: ':com.flyingsoftgames.xapkreader:library',configuration: "debug")
     releaseCompile project(path: ':com.flyingsoftgames.xapkreader:library',configuration: "release")
 }
+
+android {
+    useLibrary 'org.apache.http.legacy'
+}

--- a/android-sdk/extras/google/play_apk_expansion/downloader_library/src/com/google/android/vending/expansion/downloader/impl/V14CustomNotification.java
+++ b/android-sdk/extras/google/play_apk_expansion/downloader_library/src/com/google/android/vending/expansion/downloader/impl/V14CustomNotification.java
@@ -31,6 +31,8 @@ public class V14CustomNotification implements DownloadNotification.ICustomNotifi
     long mTotalKB = -1;
     long mCurrentKB = -1;
     long mTimeRemaining;
+    boolean mOngoing = true;
+    boolean mAutoCancel = false;
     PendingIntent mPendingIntent;
 
     @Override
@@ -68,16 +70,17 @@ public class V14CustomNotification implements DownloadNotification.ICustomNotifi
         }
         builder.setContentText(Helpers.getDownloadProgressString(mCurrentKB, mTotalKB));
         builder.setContentInfo(c.getString(R.string.time_remaining_notification,
-                Helpers.getTimeRemaining(mTimeRemaining)));
+                                           Helpers.getTimeRemaining(mTimeRemaining)));
         if (mIcon != 0) {
             builder.setSmallIcon(mIcon);
         } else {
             int iconResource = android.R.drawable.stat_sys_download;
             builder.setSmallIcon(iconResource);
         }
-        builder.setOngoing(true);
+        builder.setOngoing(mOngoing);
         builder.setTicker(mTicker);
         builder.setContentIntent(mPendingIntent);
+        builder.setAutoCancel(mAutoCancel);
         builder.setOnlyAlertOnce(true);
 
         return builder.getNotification();
@@ -97,5 +100,11 @@ public class V14CustomNotification implements DownloadNotification.ICustomNotifi
     public void setTimeRemaining(long timeRemaining) {
         mTimeRemaining = timeRemaining;
     }
+
+    @Override
+    public void setOngoing(boolean ongoing) { mOngoing = ongoing; }
+
+    @Override
+    public void setAutoCancel(boolean autoCancel) { mAutoCancel = autoCancel; }
 
 }

--- a/android-sdk/extras/google/play_apk_expansion/downloader_library/src/com/google/android/vending/expansion/downloader/impl/V3CustomNotification.java
+++ b/android-sdk/extras/google/play_apk_expansion/downloader_library/src/com/google/android/vending/expansion/downloader/impl/V3CustomNotification.java
@@ -34,6 +34,8 @@ public class V3CustomNotification implements DownloadNotification.ICustomNotific
     long mTotalBytes = -1;
     long mCurrentBytes = -1;
     long mTimeRemaining;
+    boolean mOngoing = true;
+    boolean mAutoCancel = false;
     PendingIntent mPendingIntent;
     Notification mNotification = new Notification();
 
@@ -63,35 +65,45 @@ public class V3CustomNotification implements DownloadNotification.ICustomNotific
 
         n.icon = mIcon;
 
-        n.flags |= Notification.FLAG_ONGOING_EVENT;
+        if (mOngoing) {
+            n.flags |= Notification.FLAG_ONGOING_EVENT;
+        } else {
+            n.flags &= ~Notification.FLAG_ONGOING_EVENT;
+        }
+
+        if (mAutoCancel) {
+            n.flags |= Notification.FLAG_AUTO_CANCEL;
+        } else {
+            n.flags &= ~Notification.FLAG_AUTO_CANCEL;
+        }
 
         if (android.os.Build.VERSION.SDK_INT > 10) {
             n.flags |= Notification.FLAG_ONLY_ALERT_ONCE; // only matters for
-                                                          // Honeycomb
+            // Honeycomb
         }
 
         // Build the RemoteView object
         RemoteViews expandedView = new RemoteViews(
-                c.getPackageName(),
-                R.layout.status_bar_ongoing_event_progress_bar);
+            c.getPackageName(),
+            R.layout.status_bar_ongoing_event_progress_bar);
 
         expandedView.setTextViewText(R.id.title, mTitle);
         // look at strings
         expandedView.setViewVisibility(R.id.description, View.VISIBLE);
         expandedView.setTextViewText(R.id.description,
-                Helpers.getDownloadProgressString(mCurrentBytes, mTotalBytes));
+                                     Helpers.getDownloadProgressString(mCurrentBytes, mTotalBytes));
         expandedView.setViewVisibility(R.id.progress_bar_frame, View.VISIBLE);
         expandedView.setProgressBar(R.id.progress_bar,
-                (int) (mTotalBytes >> 8),
-                (int) (mCurrentBytes >> 8),
-                mTotalBytes <= 0);
+                                    (int) (mTotalBytes >> 8),
+                                    (int) (mCurrentBytes >> 8),
+                                    mTotalBytes <= 0);
         expandedView.setViewVisibility(R.id.time_remaining, View.VISIBLE);
         expandedView.setTextViewText(
-                R.id.time_remaining,
-                c.getString(R.string.time_remaining_notification,
+            R.id.time_remaining,
+            c.getString(R.string.time_remaining_notification,
                         Helpers.getTimeRemaining(mTimeRemaining)));
         expandedView.setTextViewText(R.id.progress_text,
-                Helpers.getDownloadProgressPercent(mCurrentBytes, mTotalBytes));
+                                     Helpers.getDownloadProgressPercent(mCurrentBytes, mTotalBytes));
         expandedView.setImageViewResource(R.id.appIcon, mIcon);
         n.contentView = expandedView;
         n.contentIntent = mPendingIntent;
@@ -113,4 +125,9 @@ public class V3CustomNotification implements DownloadNotification.ICustomNotific
         mTimeRemaining = timeRemaining;
     }
 
+    @Override
+    public void setOngoing(boolean ongoing) { mOngoing = ongoing; }
+
+    @Override
+    public void setAutoCancel(boolean autoCancel) { mAutoCancel = autoCancel; }
 }

--- a/android-sdk/extras/google/play_licensing/library/build-extras.gradle
+++ b/android-sdk/extras/google/play_licensing/library/build-extras.gradle
@@ -1,0 +1,3 @@
+android {
+    useLibrary 'org.apache.http.legacy'
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,8 +8,8 @@
  <engines><engine name="cordova" version=">=4.1.1" /></engines>
  
  <platform name="android">
-  
-  <dependency id="com.google.play.services" />
+ 
+  <framework src="com.google.android.gms:play-services-base:+" />
   
   <config-file target="res/xml/config.xml" parent="/*">
    <feature name="XAPKReader">

--- a/plugin.xml
+++ b/plugin.xml
@@ -10,6 +10,10 @@
  <platform name="android">
  
   <framework src="com.google.android.gms:play-services-base:+" />
+ 
+  <js-module src="www/XAPKReader.js" name="XAPKReader">
+   <clobbers target="XAPKReader"/>
+  </js-module>
   
   <config-file target="res/xml/config.xml" parent="/*">
    <feature name="XAPKReader">
@@ -29,6 +33,7 @@
   <preference name="XAPK_PATCH_VERSION" default="0" />
   <preference name="XAPK_MAIN_FILESIZE" default="0" />
   <preference name="XAPK_PATCH_FILESIZE" default="0" />
+  <preference name="XAPK_AUTO_DOWNLOAD" default="true" />
 
   <source-file src="res/values/xapkreader.xml" target-dir="res/values" />
   <config-file target="res/values/xapkreader.xml" parent="/*">
@@ -43,6 +48,7 @@
    <integer name="xapk_patch_version">$XAPK_PATCH_VERSION</integer>
    <integer name="xapk_main_file_size">$XAPK_MAIN_FILESIZE</integer>
    <integer name="xapk_patch_file_size">$XAPK_PATCH_FILESIZE</integer>
+   <bool name="xapk_auto_download">$XAPK_AUTO_DOWNLOAD</bool>
   </config-file>
   
   <source-file src="src/android/XAPKAlarmReceiver.java"      target-dir="src/com/flyingsoftgames/xapkreader" />

--- a/src/android/XAPKReader.java
+++ b/src/android/XAPKReader.java
@@ -3,65 +3,124 @@ package com.flyingsoftgames.xapkreader;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.PluginResult;
 
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.net.Uri;
+import org.json.JSONArray;
 
 public class XAPKReader extends CordovaPlugin {
- @Override public void initialize (final CordovaInterface cordova, CordovaWebView webView) {
-  String packageName = cordova.getActivity().getPackageName();
-  final Bundle bundle = new Bundle ();
-  
-  // Get some data from the xapkreader.xml file.
-  String[][] xmlData = new String[][] {
-   {"xapk_main_version"           , "integer"},
-   {"xapk_patch_version"          , "integer"},
-   {"xapk_main_file_size"         , "integer", "long"},
-   {"xapk_patch_file_size"        , "integer", "long"},
-   {"xapk_expansion_authority"    , "string"},
-   {"xapk_text_downloading_assets", "string"},
-   {"xapk_text_preparing_assets"  , "string"},
-   {"xapk_text_download_failed"   , "string"},
-   {"xapk_text_error"             , "string"},
-   {"xapk_text_close"             , "string"},
-   {"xapk_google_play_public_key" , "string"}
-  };
-  int curlen = xmlData.length;
-  for (int i = 0; i < curlen; i++) {
-   int currentId = cordova.getActivity().getResources().getIdentifier (xmlData[i][0], xmlData[i][1], packageName);
-   if (xmlData[i][1] == "bool")    {bundle.putBoolean(xmlData[i][0], cordova.getActivity().getResources().getBoolean(currentId)); continue;}
-   if (xmlData[i][1] == "string")  {bundle.putString (xmlData[i][0], cordova.getActivity().getResources().getString (currentId)); continue;}
-   if (xmlData[i][1] == "integer") {
-    if ((xmlData[i].length == 2) || (xmlData[i][2] == "integer")) {
-     bundle.putInt  (xmlData[i][0], cordova.getActivity().getResources().getInteger(currentId)); continue;
+    public static final String ACTION_DOWNLOAD_IF_AVAIlABLE = "downloadExpansionIfAvailable";
+
+    private CordovaInterface cordova;
+    private CordovaWebView webView;
+    private Bundle bundle;
+
+    @Override
+    public void initialize(final CordovaInterface cordova, CordovaWebView webView) {
+        this.cordova = cordova;
+        this.webView = webView;
+        this.bundle = new Bundle();
+
+        String packageName = cordova.getActivity().getPackageName();
+
+        // Get some data from the xapkreader.xml file.
+        String[][] xmlData = new String[][]{
+            {"xapk_main_version", "integer"},
+            {"xapk_patch_version", "integer"},
+            {"xapk_main_file_size", "integer", "long"},
+            {"xapk_patch_file_size", "integer", "long"},
+            {"xapk_expansion_authority", "string"},
+            {"xapk_text_downloading_assets", "string"},
+            {"xapk_text_preparing_assets", "string"},
+            {"xapk_text_download_failed", "string"},
+            {"xapk_text_error", "string"},
+            {"xapk_text_close", "string"},
+            {"xapk_google_play_public_key", "string"},
+            {"xapk_auto_download", "bool"}
+        };
+        int curlen = xmlData.length;
+        for (int i = 0; i < curlen; i++) {
+            int currentId = cordova.getActivity().getResources().getIdentifier(xmlData[i][0], xmlData[i][1], packageName);
+            if (xmlData[i][1] == "bool") {
+                bundle.putBoolean(xmlData[i][0], cordova.getActivity().getResources().getBoolean(currentId));
+                continue;
+            }
+            if (xmlData[i][1] == "string") {
+                bundle.putString(xmlData[i][0], cordova.getActivity().getResources().getString(currentId));
+                continue;
+            }
+            if (xmlData[i][1] == "integer") {
+                if ((xmlData[i].length == 2) || (xmlData[i][2] == "integer")) {
+                    bundle.putInt(xmlData[i][0], cordova.getActivity().getResources().getInteger(currentId));
+                    continue;
+                }
+                if (xmlData[i][2] == "long") {
+                    bundle.putLong(xmlData[i][0], cordova.getActivity().getResources().getInteger(currentId));
+                    continue;
+                }
+            }
+        }
+
+        // Send data to the ContentProvider instance.
+        ContentResolver cr = cordova.getActivity().getApplicationContext().getContentResolver();
+        String expansionAuthority = bundle.getString("xapk_expansion_authority", "");
+        cr.call(Uri.parse("content://" + expansionAuthority), "set_expansion_file_version_data", null, bundle);
+
+        // Set the public key.
+        XAPKDownloaderService.BASE64_PUBLIC_KEY = bundle.getString("xapk_google_play_public_key", "");
+
+        boolean autoDownload = bundle.getBoolean("xapk_auto_download", true);
+        if (autoDownload) {
+            downloadExpansionIfAvailable();
+        }
+
+        super.initialize(cordova, webView);
     }
-    if (xmlData[i][2] == "long") {
-     bundle.putLong (xmlData[i][0], cordova.getActivity().getResources().getInteger(currentId)); continue;
+
+    @Override
+    public boolean execute(final String action, final JSONArray args, final CallbackContext callContext) {
+        try {
+            PluginResult result = null;
+            boolean success = false;
+
+            if (XAPKReader.ACTION_DOWNLOAD_IF_AVAIlABLE.equals(action)) {
+                downloadExpansionIfAvailable();
+                result = new PluginResult(PluginResult.Status.OK);
+                success = true;
+            } else {
+                result = new PluginResult(PluginResult.Status.ERROR, "no such action: " + action);
+            }
+
+            callContext.sendPluginResult(result);
+            return success;
+
+        } catch (Exception ex) {
+            String message = ex.getMessage();
+            PluginResult result = new PluginResult(PluginResult.Status.ERROR, action + ": exception thown, " + message);
+            result.setKeepCallback(false);
+
+            callContext.sendPluginResult(result);
+            return true;
+        }
     }
-   }
-  }
-  
-  // Send data to the ContentProvider instance.
-  ContentResolver cr = cordova.getActivity().getApplicationContext().getContentResolver();
-  String expansionAuthority = bundle.getString("xapk_expansion_authority", "");
-  cr.call (Uri.parse("content://" + expansionAuthority), "set_expansion_file_version_data", null, bundle);
-  
-  // Set the public key.
-  XAPKDownloaderService.BASE64_PUBLIC_KEY = bundle.getString("xapk_google_play_public_key", "");
-  
-  cordova.getActivity().runOnUiThread (new Runnable() {
-   @Override public void run () {
-    XAPKDownloaderActivity.cordovaActivity = cordova.getActivity(); // Workaround for Cordova/Crosswalk flickering status bar bug.
-    Context context = cordova.getActivity().getApplicationContext();
-    Intent intent = new Intent(context, XAPKDownloaderActivity.class);
-    intent.putExtras (bundle);
-    cordova.getActivity().startActivity (intent);
-   }
-  });
-  
-  super.initialize (cordova, webView);
- }
+
+
+    private void downloadExpansionIfAvailable() {
+        cordova.getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                XAPKDownloaderActivity.cordovaActivity = cordova.getActivity(); // Workaround for Cordova/Crosswalk flickering status bar bug.
+                Context context = cordova.getActivity().getApplicationContext();
+                Intent intent = new Intent(context, XAPKDownloaderActivity.class);
+                intent.putExtras(bundle);
+                cordova.getActivity().startActivity(intent);
+            }
+        });
+    }
 }

--- a/www/XAPKReader.js
+++ b/www/XAPKReader.js
@@ -1,0 +1,6 @@
+var exec = require('cordova/exec');
+var utils = require('cordova/utils');
+
+exports.downloadExpansionIfAvailable = function(successCB, errorCB) {
+  exec(successCB, errorCB, "XAPKReader", "downloadExpansionIfAvailable");
+};


### PR DESCRIPTION
- Added apache legacy http library as a dependency for google play licensing and downloader libraries to fix compilation issues on sdk 23+.
- Replaced use of dependency tag with framework tag to pull in com.google.play.services without implicitly pulling in google-play-services plugin per deprecation comment on https://github.com/MobileChromeApps/google-play-services.
- Added option to explicitly invoke expansion file download from JavaScript instead of automatically downloading expansion files as soon as the application starts up.  This resolves the timing issue with cordova-plugin-splashscreen identified here: https://github.com/agamemnus/cordova-plugin-xapkreader/issues/16 by allowing the application to specifically invoke expansion file download after the splash screen is removed.


