### PR TITLE
Don't url-encode paths in the ZIP file

### DIFF
--- a/src/android/XAPKProvider.java
+++ b/src/android/XAPKProvider.java
@@ -108,7 +108,9 @@ public class XAPKProvider extends ContentProvider {
  
  public AssetFileDescriptor openAssetFile (Uri uri, String mode) throws FileNotFoundException {
   if (initIfNecessary () == false) throw new FileNotFoundException ();
-  String path = uri.getEncodedPath ();
+  // Use uri.getPath() instead of uri.getEncodedPath(), because the paths inside the ZIP
+  // file are filesystem paths, not url-encoded paths.
+  String path = uri.getPath ();
   if (path.startsWith("/")) path = path.substring (1);
   AssetFileDescriptor result;
   try {


### PR DESCRIPTION
The filenames inside the ZIP file use filesystem naming standards, not URL standards, so we need to search for them by the decoded path, not the url-encoded path.

Test case:
1. Create an expansion file containing a file with a space in its name, e.g. "test file.png"
2. Put an img tag for this file in your app, e.g. &lt;img src="content://org.example.expansion/test%20file.png" />
3. Try to view the image in the app

Expected result: You view the image
Actual result: Broken image, and the app throws a FileNotFoundException.

This happens because the code unnecessarily uses URI.getEncodedPath() to decide the name of the file to look for in the zip archive. Which means it looks for a file named "test%20file.png" instead of "test file.png". (The URL for the file, on the Cordova side of things, does need to be url-encoded of course. But Android automatically url-decodes it before passing it to the ContentProvider class, and we need to keep it url-decoded in order to match the filenames inside the zip archive.)