### PR TITLE
Reload webview after download is complete

### DIFF
--- a/src/android/XAPKDownloaderActivity.java
+++ b/src/android/XAPKDownloaderActivity.java
@@ -27,6 +27,7 @@ import com.google.android.vending.expansion.downloader.IDownloaderClient;
 import com.google.android.vending.expansion.downloader.IDownloaderService;
 import com.google.android.vending.expansion.downloader.IStub;
 
+import org.apache.cordova.CordovaWebView;
 import java.io.File;
 import java.io.ByteArrayInputStream;
 import java.security.cert.CertificateException;
@@ -45,6 +46,9 @@ public class XAPKDownloaderActivity extends Activity implements IDownloaderClien
  // <Workaround for Cordova/Crosswalk flickering status bar bug./>
  public static Activity cordovaActivity = null;
  // <Workaround for Cordova/Crosswalk flickering status bar bug./>
+ // The Cordova webview, so we can tell it to reload the page once the contents
+ // have been received.
+ public static CordovaWebView cordovaWebView = null;
  
  // The file may have been delivered by Google Play --- let's make sure it exists and it's the size we expect.
  static public boolean validateFile (Context ctx, String fileName, long fileSize, boolean checkFileSize) {
@@ -181,7 +185,18 @@ public class XAPKDownloaderActivity extends Activity implements IDownloaderClien
   ) {Log.v (LOG_TAG, "Downloading..."); return;}
   
   if (newState == STATE_COMPLETED) {
+   Log.v(LOG_TAG, "Download complete");
    mProgressDialog.setMessage (xmlData.getString("xapk_text_preparing_assets", ""));
+   if (cordovaWebView != null) {
+    // We need to reload the webview (if it's still open), in case
+    // it's already displaying some images from the expansion, as broken
+    // image links.
+    Log.v(LOG_TAG, "Reloading Cordova webview");
+    cordovaWebView.loadUrl(cordovaWebView.getUrl());
+   }
+   else {
+    Log.w(LOG_TAG, "Couldn't reload Cordova webview");
+   }
    
    // Dismiss progress dialog.
    mProgressDialog.dismiss ();

--- a/src/android/XAPKProvider.java
+++ b/src/android/XAPKProvider.java
@@ -15,6 +15,7 @@ import android.net.Uri;
 import android.os.ParcelFileDescriptor;
 import android.os.Bundle;
 import android.provider.BaseColumns;
+import android.util.Log;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -32,6 +33,7 @@ public class XAPKProvider extends ContentProvider {
  public static final String COMPRESSEDLEN   = "ZCOL";
  public static final String UNCOMPRESSEDLEN = "ZUNL";
  public static final String COMPRESSIONTYPE = "ZTYP";
+ private static final String LOG_TAG = "XAPKDownloader";
  
  public static final String[] ALL_FIELDS = {
   FILEID,
@@ -93,14 +95,21 @@ public class XAPKProvider extends ContentProvider {
  }
  
  public boolean initIfNecessary () {
-  if (xmlDataReceived == false) return false;
-  if (mInit) return true;
+  if (xmlDataReceived == false) {
+   Log.e(LOG_TAG, "Could not init provider because XML data hasn't been loaded");
+   return false;
+  }
+  if (mInit) {
+   return true;
+  }
   Context ctx = getContext ();
   try {
    mAPKExtensionFile = XAPKExpansionSupport.getAPKExpansionZipFile (ctx, mainFileVersion, patchFileVersion);
    mInit = true;
+   Log.v(LOG_TAG, "Successfully init'ed provider.");
    return true;
   } catch (IOException e) {
+   Log.w(LOG_TAG, "Could not open expansion ZIP file");
    e.printStackTrace ();
   }
   return false;

--- a/src/android/XAPKReader.java
+++ b/src/android/XAPKReader.java
@@ -116,6 +116,9 @@ public class XAPKReader extends CordovaPlugin {
             @Override
             public void run() {
                 XAPKDownloaderActivity.cordovaActivity = cordova.getActivity(); // Workaround for Cordova/Crosswalk flickering status bar bug.
+                // Provide webview to Downloader Activity so it can trigger a page
+                // reload once the expansion is downloaded.
+                XAPKDownloaderActivity.cordovaWebView = webView;
                 Context context = cordova.getActivity().getApplicationContext();
                 Intent intent = new Intent(context, XAPKDownloaderActivity.class);
                 intent.putExtras(bundle);


### PR DESCRIPTION
If the webview was already loaded, but showed some images an broken links because the expansion
file wasn't present yet, then we'll need to reload it once the expansion is downloaded.

I wrote this patch originally on my fork of the project, before the "automatic download" flag was added to the app. With automatic download, you don't see any part of the app, really, until the download is complete, so it doesn't matter if I force refresh the webview. I'm not sure if that's true when you disable automatic download.