### PR TITLE
Feature: Change progress display to MB instead of percent

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ The plugin provides the following variables, which you can set in your app's `co
 - **XAPK_EXPANSION_AUTHORITY (Highly recommended)**: The [URI "authority"][2] string the plugin should use. This provides an easy way for you to access your expansion files' contents via URLs in the Cordova app. This name must be unique, so it's recommended to match your app's package name, or at least start with it, e.g. "org.example.mycordova" or "org.example.mycordova.expansion". **Any other app may access this data**: you can actually share data between apps that use the same url/expansion authority!
   - *Default:* The package name of your app (e.g. the "id" attribute in your config.xml's "widget" tag).
 - **XAPK_AUTO_DOWNLOAD**: Controls whether or not the plugin starts downloading automatically when the app launches. If true, the plugin will take over the app's UI with its downloader immediately upon launch, if files need to be downloaded. If false, your Cordova app will need to tell the plugin to initiate the Downloader. See [Compatibility with cordova-plugin-splashscreen](#Compatibility with cordova-plugin-splashscreen)
+- **XAPK_PROGRESS_FORMAT**: Controls the formatting of the download progress dialogue. Recognized values are `percent` (show percentage downloaded) and `megabytes` (show number of megabytes downloaded, out of total).
+  - *Default:* `percent`
 - *Text strings*: The following variables are text strings that are displayed to the user as part of the plugin's user interface. They're exposed as variables in case you want to translate or change them.
   - **XAPK_TEXT_DL_ASSETS**: "Downloading assets..."
   - **XAPK_TEXT_PR_ASSETS**: "Preparing assets..."

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,6 +34,7 @@
   <preference name="XAPK_MAIN_FILESIZE" default="0" />
   <preference name="XAPK_PATCH_FILESIZE" default="0" />
   <preference name="XAPK_AUTO_DOWNLOAD" default="true" />
+  <preference name="XAPK_PROGRESS_FORMAT" default="percent" />
 
   <source-file src="res/values/xapkreader.xml" target-dir="res/values" />
   <config-file target="res/values/xapkreader.xml" parent="/*">
@@ -49,6 +50,7 @@
    <integer name="xapk_main_file_size">$XAPK_MAIN_FILESIZE</integer>
    <integer name="xapk_patch_file_size">$XAPK_PATCH_FILESIZE</integer>
    <bool name="xapk_auto_download">$XAPK_AUTO_DOWNLOAD</bool>
+   <string name="xapk_progress_format">$XAPK_PROGRESS_FORMAT</string>
   </config-file>
   
   <source-file src="src/android/XAPKAlarmReceiver.java"      target-dir="src/com/flyingsoftgames/xapkreader" />

--- a/src/android/XAPKDownloaderActivity.java
+++ b/src/android/XAPKDownloaderActivity.java
@@ -131,6 +131,16 @@ public class XAPKDownloaderActivity extends Activity implements IDownloaderClien
    mProgressDialog.setProgressStyle (ProgressDialog.STYLE_HORIZONTAL);
    mProgressDialog.setMessage (xmlData.getString("xapk_text_downloading_assets", ""));
    mProgressDialog.setCancelable (false);
+   int max = 0;
+   for (int i = 0; i < fileSizeList.length; i++) {
+    if (fileSizeList[i] > 0) {
+     max += fileSizeList[i];
+    }
+   }
+   if (max > 0) {
+    mProgressDialog.setMax((int) (fileSizeList[0] / 1024 / 1024));
+   }
+   mProgressDialog.setProgressNumberFormat("%1dMB /%2dMB");
    mProgressDialog.show ();
    return;
    
@@ -172,7 +182,11 @@ public class XAPKDownloaderActivity extends Activity implements IDownloaderClien
  @Override public void onDownloadProgress (DownloadProgressInfo progress) {
   long percents = progress.mOverallProgress * 100 / progress.mOverallTotal;
   Log.v (LOG_TAG, "DownloadProgress: " + Long.toString(percents) + "%");
-  mProgressDialog.setProgress((int) percents);
+  mProgressDialog.setProgress((int) progress.mOverallProgress / 1024 / 1024);
+  int max = (int) progress.mOverallTotal / 1024 / 1024;
+  if (mProgressDialog.getMax() != max) {
+   mProgressDialog.setMax(max);
+  }
  }
 
  @Override public void onDownloadStateChanged (int newState) {

--- a/src/android/XAPKReader.java
+++ b/src/android/XAPKReader.java
@@ -42,7 +42,8 @@ public class XAPKReader extends CordovaPlugin {
             {"xapk_text_error", "string"},
             {"xapk_text_close", "string"},
             {"xapk_google_play_public_key", "string"},
-            {"xapk_auto_download", "bool"}
+            {"xapk_auto_download", "bool"},
+            {"xapk_progress_format", "string"}
         };
         int curlen = xmlData.length;
         for (int i = 0; i < curlen; i++) {


### PR DESCRIPTION
This patch changes the download progress to display the number of megabytes, instead of the percentage.

The expansion file for my app is about 350MB, so I found it was more helpful for users to be able to tell how much more data they were waiting for, than the percentage. But that may not be the case for other projects. Perhaps I should add some additional code to make this an optional setting?