### PR TITLE
Remove Autodownloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,24 +101,6 @@ cordova plugin add https://github.com/agamemnus/cordova-plugin-xapkreader.git#co
 
 ## Plugin Config Variables
 
-The plugin provides the following variables, which you can set in your app's `config.xml` file, or by adding the `--variable` flag (per variable, as above) to `cordova plugin add`.
-
-- **XAPK_PUBLIC_KEY (Required)**: The [Services & APIs public key][1] from your Google Play developer account. Google requires the app to provide this in order to download the expansion files from its servers.
-- **XAPK_EXPANSION_AUTHORITY (Highly recommended)**: The [URI "authority"][2] string the plugin should use. This provides an easy way for you to access your expansion files' contents via URLs in the Cordova app. This name must be unique, so it's recommended to match your app's package name, or at least start with it, e.g. "org.example.mycordova" or "org.example.mycordova.expansion". **Any other app may access this data**: you can actually share data between apps that use the same url/expansion authority!
-  - *Default:* The package name of your app (e.g. the "id" attribute in your config.xml's "widget" tag).
-- **XAPK_AUTO_DOWNLOAD**: Controls whether or not the plugin starts downloading automatically when the app launches. If true, the plugin will take over the app's UI with its downloader immediately upon launch, if files need to be downloaded. If false, your Cordova app will need to tell the plugin to initiate the Downloader. See [Compatibility with cordova-plugin-splashscreen](#Compatibility with cordova-plugin-splashscreen)
-- **XAPK_PROGRESS_FORMAT**: Controls the formatting of the download progress dialogue. Recognized values are `percent` (show percentage downloaded) and `megabytes` (show number of megabytes downloaded, out of total).
-  - *Default:* `percent`
-- *Text strings*: The following variables are text strings that are displayed to the user as part of the plugin's user interface. They're exposed as variables in case you want to translate or change them.
-  - **XAPK_TEXT_DL_ASSETS**: "Downloading assets..."
-  - **XAPK_TEXT_PR_ASSETS**: "Preparing assets..."
-  - **XAPK_TEXT_DL_FAILED**: "Download failed."
-  - **XAPK_TEXT_ERROR**: "Error."
-  - **XAPK_TEXT_CLOSE**: "Close." (as in close a window)
-  
-There are a few others that in almost every case you don't need to worry about setting, as the defaults should be just fine:
-
-- **XAPK_MAIN_VERSION**: The [version number][3] for your "main" expansion file.
   - *Default:*: 0: Indicates that the app should use the first file it finds in the expansion directory that has a name starting with "main". (Google Play tries to ensure that you will never have more than one `main` and one `patch` file, so usually you don't need to worry about checking that their version numbers are correct.)
   - *If provided*: If not 0, the plugin will only use an expansion file with this version number.
 - **XAPK_MAIN_FILESIZE**: The size (in bytes) of your "main" expansion file.
@@ -139,7 +121,7 @@ There are a few others that in almost every case you don't need to worry about s
 
 ## Expansion files (OBB files)
 
-The expansion file should be a non-compressed ZIP file (also known as a "STOR" or "store"). That is, a ZIP file with 0% compression. Your ZIP file *can* include a directory structure, which can help to keep the files organized. 
+The expansion file should be a non-compressed ZIP file (also known as a "STOR" or "store"). That is, a ZIP file with 0% compression. Your ZIP file *can* include a directory structure, which can help to keep the files organized.
 
 In Ubuntu Linux, you can generate a non-compressed zip file by adding the `-0` flag to the standard CLI `zip` command.
 
@@ -162,7 +144,7 @@ This plugin helps you to do that, by preferring files in `patch` over files in `
 ## In Cordova
 
 Remember that expansion authority URI you set up in `XAPK_EXPANSION_AUTHORITY`? You can reference your expansion files from within your Cordova app, using an [Android Content URI][1] which includes your expansion authority string.
- 
+
 ```html
 <img src="content://org.example.mycordova/myfile.png">
 ```
@@ -190,24 +172,6 @@ Note that if your app is cross-platform (and that's a big part of Cordova's appe
 * If you **manually rename** the main or patch file on your device while the app is running, the .obb (zip) file <--> URI mappings will break because the plugin won't run and remap every time you open the app. If you reinstall, the device will rename the files.
 
 * If you upload a new main or patch APK expansion file to Google Play, the old main or patch file will be deleted when Google Play updates the user's device.
-
-
-# Compatibility with cordova-plugin-splashscreen
-If you are using `cordova-plugin-splashscreen`, by default this plugin will prevent your splash screen from appearing on Android.  This is because `cordova-plugin-splashscreen` is wired to automatically hide the splash screen after receiving a pause event.  When this plugin activates the download activity, the pause event is fired, and the splash screen is hidden.
-   
-To avoid this behavior, you'll want to set `XAPK_AUTO_DOWNLOAD` to `false` and invoke the plugin explicitly within your Javascript code by calling `XAPKReader.downloadExpansionIfAvailable`. Add the following in your javascript code at the earliest point where you know the splash page has been removed (either by explicitly hiding it or based on the timeout you set for the splashpage).
-
-```javascript
-    // XAPKReader will only be defined (and should only be invoked) for the Android platform
-    if (window.XAPKReader) {
-      window.XAPKReader.downloadExpansionIfAvailable(function () {
-        console.log("Expansion file check/download success.");
-      }, function (err) {
-        console.log(err);
-        throw "Failed to download expansion file.";
-      })
-    }
-```
 
 # License
 (for any non-Android SDK parts...)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Table of Contents
   - [Testing](#testing)
   - [Cross-platform support](#Cross-platform-support)
 - [Tips](#tips)
-- [Compatibility with cordova-plugin-splashscreen](#compatibility-with-cordova-plugin-splashscreen)
 - [License](#license)
 
 # Version
@@ -101,6 +100,23 @@ cordova plugin add https://github.com/agamemnus/cordova-plugin-xapkreader.git#co
 
 ## Plugin Config Variables
 
+The plugin provides the following variables, which you can set in your app's `config.xml` file, or by adding the `--variable` flag (per variable, as above) to `cordova plugin add`.
+
+- **XAPK_PUBLIC_KEY (Required)**: The [Services & APIs public key][1] from your Google Play developer account. Google requires the app to provide this in order to download the expansion files from its servers.
+- **XAPK_EXPANSION_AUTHORITY (Highly recommended)**: The [URI "authority"][2] string the plugin should use. This provides an easy way for you to access your expansion files' contents via URLs in the Cordova app. This name must be unique, so it's recommended to match your app's package name, or at least start with it, e.g. "org.example.mycordova" or "org.example.mycordova.expansion". **Any other app may access this data**: you can actually share data between apps that use the same url/expansion authority!
+  - *Default:* The package name of your app (e.g. the "id" attribute in your config.xml's "widget" tag).
+- **XAPK_PROGRESS_FORMAT**: Controls the formatting of the download progress dialogue. Recognized values are `percent` (show percentage downloaded) and `megabytes` (show number of megabytes downloaded, out of total).
+  - *Default:* `percent`
+- *Text strings*: The following variables are text strings that are displayed to the user as part of the plugin's user interface. They're exposed as variables in case you want to translate or change them.
+  - **XAPK_TEXT_DL_ASSETS**: "Downloading assets..."
+  - **XAPK_TEXT_PR_ASSETS**: "Preparing assets..."
+  - **XAPK_TEXT_DL_FAILED**: "Download failed."
+  - **XAPK_TEXT_ERROR**: "Error."
+  - **XAPK_TEXT_CLOSE**: "Close." (as in close a window)
+
+There are a few others that in almost every case you don't need to worry about setting, as the defaults should be just fine:
+
+- **XAPK_MAIN_VERSION**: The [version number][3] for your "main" expansion file.
   - *Default:*: 0: Indicates that the app should use the first file it finds in the expansion directory that has a name starting with "main". (Google Play tries to ensure that you will never have more than one `main` and one `patch` file, so usually you don't need to worry about checking that their version numbers are correct.)
   - *If provided*: If not 0, the plugin will only use an expansion file with this version number.
 - **XAPK_MAIN_FILESIZE**: The size (in bytes) of your "main" expansion file.

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,15 +6,15 @@
  <license>MIT (see readme.md)</license>
  <keywords>cordova,apk,expansion,file,xapk,expansion file reader,xapk reader,xapkreader,android,agamemnus,flyingsoftgames</keywords>
  <engines><engine name="cordova" version=">=4.1.1" /></engines>
- 
+
  <platform name="android">
- 
+
   <framework src="com.google.android.gms:play-services-base:+" />
- 
+
   <js-module src="www/XAPKReader.js" name="XAPKReader">
    <clobbers target="XAPKReader"/>
   </js-module>
-  
+
   <config-file target="res/xml/config.xml" parent="/*">
    <feature name="XAPKReader">
     <param name="android-package" value="com.flyingsoftgames.xapkreader.XAPKReader"/>
@@ -33,7 +33,6 @@
   <preference name="XAPK_PATCH_VERSION" default="0" />
   <preference name="XAPK_MAIN_FILESIZE" default="0" />
   <preference name="XAPK_PATCH_FILESIZE" default="0" />
-  <preference name="XAPK_AUTO_DOWNLOAD" default="true" />
   <preference name="XAPK_PROGRESS_FORMAT" default="percent" />
 
   <source-file src="res/values/xapkreader.xml" target-dir="res/values" />
@@ -49,10 +48,9 @@
    <integer name="xapk_patch_version">$XAPK_PATCH_VERSION</integer>
    <integer name="xapk_main_file_size">$XAPK_MAIN_FILESIZE</integer>
    <integer name="xapk_patch_file_size">$XAPK_PATCH_FILESIZE</integer>
-   <bool name="xapk_auto_download">$XAPK_AUTO_DOWNLOAD</bool>
    <string name="xapk_progress_format">$XAPK_PROGRESS_FORMAT</string>
   </config-file>
-  
+
   <source-file src="src/android/XAPKAlarmReceiver.java"      target-dir="src/com/flyingsoftgames/xapkreader" />
   <source-file src="src/android/XAPKDownloaderActivity.java" target-dir="src/com/flyingsoftgames/xapkreader" />
   <source-file src="src/android/XAPKDownloaderService.java"  target-dir="src/com/flyingsoftgames/xapkreader" />
@@ -60,10 +58,10 @@
   <source-file src="src/android/XAPKProvider.java"           target-dir="src/com/flyingsoftgames/xapkreader" />
   <source-file src="src/android/XAPKReader.java"             target-dir="src/com/flyingsoftgames/xapkreader" />
   <source-file src="src/android/XAPKZipResourceFile.java"    target-dir="src/com/flyingsoftgames/xapkreader" />
-  
+
   <framework src="android-sdk/extras/google/play_apk_expansion/downloader_library" custom="true"/>
   <framework src="android-sdk/extras/google/play_licensing/library" custom="true" />
-  
+
   <config-file target="AndroidManifest.xml" parent="/manifest">
    <!-- Required to download files from Google Play -->
    <uses-permission android:name="android.permission.INTERNET" />
@@ -78,7 +76,7 @@
    <!-- Required to access Google Play Licensing -->
    <uses-permission android:name="com.android.vending.CHECK_LICENSE" />
   </config-file>
-  
+
   <config-file target="AndroidManifest.xml" parent="application">
    <activity android:name="com.flyingsoftgames.xapkreader.XAPKDownloaderActivity" android:label="@string/app_name" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale">
    </activity>
@@ -86,8 +84,8 @@
    <receiver android:name="com.flyingsoftgames.xapkreader.XAPKAlarmReceiver" />
    <provider android:authorities="@string/xapk_expansion_authority" android:exported="false" android:multiprocess="true" android:name="com.flyingsoftgames.xapkreader.XAPKProvider" />
   </config-file>
-  
+
   <info> See the README.md file to complete your installation.</info>
-  
+
  </platform>
 </plugin>

--- a/src/android/XAPKReader.java
+++ b/src/android/XAPKReader.java
@@ -50,7 +50,6 @@ public class XAPKReader extends CordovaPlugin {
             {"xapk_text_error", "string"},
             {"xapk_text_close", "string"},
             {"xapk_google_play_public_key", "string"},
-            {"xapk_auto_download", "bool"},
             {"xapk_progress_format", "string"}
         };
         int curlen = xmlData.length;
@@ -92,21 +91,9 @@ public class XAPKReader extends CordovaPlugin {
         ) {
             // We need the permission; so request it (asynchronously, callback is onRequestPermissionsResult)
             cordova.requestPermission(this, STARTUP_REQ_CODE, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-        } else {
-            // We don't need the permission, or we already have it.
-            this.autodownloadIfNecessary();
         }
 
         super.initialize(cordova, webView);
-    }
-
-    public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
-        for (int r:grantResults) {
-            // They granted us WRITE_EXTERNAL_STORAGE (and thus, implicitly, READ_EXTERNAL_STORAGE) permission
-            if (requestCode == STARTUP_REQ_CODE && r == PackageManager.PERMISSION_GRANTED) {
-                this.autodownloadIfNecessary();
-            }
-        }
     }
 
     @Override
@@ -133,13 +120,6 @@ public class XAPKReader extends CordovaPlugin {
 
             callContext.sendPluginResult(result);
             return true;
-        }
-    }
-
-    private void autodownloadIfNecessary() {
-        boolean autoDownload = bundle.getBoolean("xapk_auto_download", true);
-        if (autoDownload) {
-            downloadExpansionIfAvailable();
         }
     }
 


### PR DESCRIPTION
Using this plugin I get an error on boot when it tries to download the OBB file and setting the variable XAPK_AUTO_DOWNLOAD to false it was unsuccessful and I noticed that the play store is already download the obb file by default so I went nuke and remove all the code related to the autodownload and now everything is working perfectly and as a byproduct the splashscreen started working again.