### PR TITLE
Fixing permission issues in android 7

### DIFF
--- a/src/android/XAPKReader.java
+++ b/src/android/XAPKReader.java
@@ -87,7 +87,7 @@ public class XAPKReader extends CordovaPlugin {
         // Workaround for Android 6 bug wherein downloaded OBB files have the wrong file permissions
         // and require WRITE_EXTERNAL_STORAGE permission
         if (
-                Build.VERSION.SDK_INT == 23
+                Build.VERSION.SDK_INT >= 23
                 && !cordova.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
         ) {
             // We need the permission; so request it (asynchronously, callback is onRequestPermissionsResult)


### PR DESCRIPTION
Because of the strict check on version, android 7 was breaking on attempting to read from the zip file. Should resolve #105 