### PR TITLE
Using a built-in method for getting OBB path

### DIFF
--- a/src/android/XAPKExpansionSupport.java
+++ b/src/android/XAPKExpansionSupport.java
@@ -23,9 +23,8 @@ public class XAPKExpansionSupport {
   if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) return ret.toArray (new String[0]);
   
   // Build the full path to the app's expansion files.
-  File root = Environment.getExternalStorageDirectory ();
-  String expPathString = root.toString() + EXP_PATH + packageName;
-  File expPath = new File(expPathString);
+  File expPath = ctx.getObbDir();
+  String expPathString = expPath.getAbsolutePath();
   
   // Check that the expansion file path exists.
   if (!expPath.exists()) return ret.toArray (new String[0]);


### PR DESCRIPTION
It appears [this method](https://developer.android.com/reference/android/content/Context#getObbDir())
should give us the same thing without requiring us to build the path
ourselves. Potentially less error prone?